### PR TITLE
[CONSUL-616] Add Windows Images to Struct

### DIFF
--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -61,7 +61,6 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 
 	// Assign values to the variables depending on the OS
 	if isWindows(pod) {
-		// TODO -> Update webhook struct CONSUL-599
 		dataplaneImage = w.ImageConsulDataplaneWindows
 		connectInjectDir = "C:\\consul\\connect-inject"
 	} else {

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -62,7 +62,7 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 	// Assign values to the variables depending on the OS
 	if isWindows(pod) {
 		// TODO -> Update webhook struct CONSUL-599
-		dataplaneImage = "windows consul dataplane image"
+		dataplaneImage = w.ImageConsulDataplaneWindows
 		connectInjectDir = "C:\\consul\\connect-inject"
 	} else {
 		dataplaneImage = w.ImageConsulDataplane

--- a/control-plane/connect-inject/webhook/container_init.go
+++ b/control-plane/connect-inject/webhook/container_init.go
@@ -45,7 +45,7 @@ func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, 
 		// Windows resolves DNS addresses differently. Read more: https://github.com/hashicorp-education/learn-consul-k8s-windows/blob/main/WindowsTroubleshooting.md#encountered-issues
 		consulAddress, _, _ = strings.Cut(w.ConsulAddress, ".")
 		// TODO -> Update webhook struct CONSUL-599
-		imageConsulK8s = "windows consul k8s control plane image"
+		imageConsulK8s = w.ImageConsulK8SWindows
 		initContainerCommandInterpreter = "sh"
 		initContainerCommandTpl = initContainerCommandTplWindows
 	} else {

--- a/control-plane/connect-inject/webhook/container_init.go
+++ b/control-plane/connect-inject/webhook/container_init.go
@@ -44,7 +44,6 @@ func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, 
 		connectInjectDir = "C:\\consul\\connect-inject"
 		// Windows resolves DNS addresses differently. Read more: https://github.com/hashicorp-education/learn-consul-k8s-windows/blob/main/WindowsTroubleshooting.md#encountered-issues
 		consulAddress, _, _ = strings.Cut(w.ConsulAddress, ".")
-		// TODO -> Update webhook struct CONSUL-599
 		imageConsulK8s = w.ImageConsulK8SWindows
 		initContainerCommandInterpreter = "sh"
 		initContainerCommandTpl = initContainerCommandTplWindows

--- a/control-plane/connect-inject/webhook/mesh_webhook.go
+++ b/control-plane/connect-inject/webhook/mesh_webhook.go
@@ -60,14 +60,20 @@ type MeshWebhook struct {
 
 	// ImageConsul is the container image for Consul to use.
 	// ImageConsulDataplane is the container image for Envoy to use.
+	// ImageConsulWindows is the Windows container image for Consul to use.
+	// ImageConsulDataplaneWindows is the Windows container image for Envoy to use.
 	//
 	// Both of these MUST be set.
-	ImageConsul          string
-	ImageConsulDataplane string
+	ImageConsul                 string
+	ImageConsulDataplane        string
+	ImageConsulWindows          string
+	ImageConsulDataplaneWindows string
 
 	// ImageConsulK8S is the container image for consul-k8s to use.
+	// ImageConsulK8SWindows is the Windows container image for consul-k8s to use.
 	// This image is used for the consul-sidecar container.
-	ImageConsulK8S string
+	ImageConsulK8S        string
+	ImageConsulK8SWindows string
 
 	// Optional: set when you need extra options to be set when running envoy
 	// See a list of args here: https://www.envoyproxy.io/docs/envoy/latest/operations/cli


### PR DESCRIPTION
# Description:

- Added Windows images to MeshWebhook struct:
  - ImageConsulDataplaneWindows
  - ImageConsulWindows: this image currently is not used, it was added just to be aligned with original code.
  - ImageConsulK8SWindows
- Replaced place-holders with struct values.

