### PR TITLE
[CONSUL-636] Apply Code Review: Consul Address

### DIFF
--- a/charts/consul/templates/_helpers.tpl
+++ b/charts/consul/templates/_helpers.tpl
@@ -286,7 +286,7 @@ Consul server environment variables for consul-k8s commands.
   {{- if .Values.externalServers.enabled }}
   value: {{ .Values.externalServers.hosts | first }}
   {{- else }}
-  value: {{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc
+  value: {{ template "consul.fullname" . }}-server.{{ .Release.Namespace }}.svc.cluster.local
   {{- end }}
 - name: CONSUL_GRPC_PORT
   {{- if .Values.externalServers.enabled }}

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar.go
@@ -186,14 +186,11 @@ func (w *MeshWebhook) consulDataplaneSidecar(namespace corev1.Namespace, pod cor
 }
 
 func (w *MeshWebhook) getContainerSidecarArgs(namespace corev1.Namespace, mpi multiPortInfo, bearerTokenFile string, pod corev1.Pod) ([]string, error) {
-	var proxyIDFileName, consulAddress string
+	var proxyIDFileName string
 	if isWindows(pod) {
 		proxyIDFileName = "C:\\consul\\connect-inject\\proxyid"
-		// Windows resolves DNS addresses differently. Read more: https://github.com/hashicorp-education/learn-consul-k8s-windows/blob/main/WindowsTroubleshooting.md#encountered-issues
-		consulAddress, _, _ = strings.Cut(w.ConsulAddress, ".")
 	} else {
 		proxyIDFileName = "/consul/connect-inject/proxyid"
-		consulAddress = w.ConsulAddress
 	}
 
 	if mpi.serviceName != "" {
@@ -216,7 +213,7 @@ func (w *MeshWebhook) getContainerSidecarArgs(namespace corev1.Namespace, mpi mu
 	}
 
 	args := []string{
-		"-addresses", consulAddress,
+		"-addresses", w.ConsulAddress,
 		"-grpc-port=" + strconv.Itoa(w.ConsulConfig.GRPCPort),
 		"-proxy-service-id-path=" + proxyIDFileName,
 		"-log-level=" + w.LogLevel,

--- a/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
+++ b/control-plane/connect-inject/webhook/consul_dataplane_sidecar_test.go
@@ -1254,7 +1254,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{GRPCPort: 8502},
 				LogLevel:      "info",
 				LogJSON:       false,
@@ -1273,7 +1273,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{GRPCPort: 8602},
 				LogLevel:      "info",
 				LogJSON:       false,
@@ -1292,7 +1292,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{GRPCPort: 8502},
 				LogLevel:      "info",
 				LogJSON:       false,
@@ -1313,7 +1313,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:        "consul-server.default.svc",
+				ConsulAddress:        "consul-server.default.svc.cluster.local",
 				ConsulConfig:         &consul.Config{GRPCPort: 8502},
 				LogLevel:             "info",
 				LogJSON:              false,
@@ -1336,7 +1336,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:              "consul-server.default.svc",
+				ConsulAddress:              "consul-server.default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{GRPCPort: 8502},
 				LogLevel:                   "info",
 				LogJSON:                    false,
@@ -1359,7 +1359,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:   "consul-server.default.svc",
+				ConsulAddress:   "consul-server.default.svc.cluster.local",
 				ConsulConfig:    &consul.Config{GRPCPort: 8502},
 				LogLevel:        "info",
 				LogJSON:         false,
@@ -1381,7 +1381,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:       "consul-server.default.svc",
+				ConsulAddress:       "consul-server.default.svc.cluster.local",
 				ConsulConfig:        &consul.Config{GRPCPort: 8502},
 				LogLevel:            "info",
 				LogJSON:             false,
@@ -1403,7 +1403,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:       "consul-server.default.svc",
+				ConsulAddress:       "consul-server.default.svc.cluster.local",
 				ConsulConfig:        &consul.Config{GRPCPort: 8502},
 				LogLevel:            "info",
 				LogJSON:             false,
@@ -1424,7 +1424,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:              "consul-server.default.svc",
+				ConsulAddress:              "consul-server.default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{GRPCPort: 8502},
 				LogLevel:                   "info",
 				LogJSON:                    false,
@@ -1445,7 +1445,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:        "consul-server.default.svc",
+				ConsulAddress:        "consul-server.default.svc.cluster.local",
 				ConsulConfig:         &consul.Config{GRPCPort: 8502},
 				LogLevel:             "info",
 				LogJSON:              false,
@@ -1466,7 +1466,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:        "consul-server.default.svc",
+				ConsulAddress:        "consul-server.default.svc.cluster.local",
 				ConsulConfig:         &consul.Config{GRPCPort: 8502},
 				LogLevel:             "info",
 				LogJSON:              false,
@@ -1488,7 +1488,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:   "consul-server.default.svc",
+				ConsulAddress:   "consul-server.default.svc.cluster.local",
 				ConsulConfig:    &consul.Config{GRPCPort: 8502},
 				LogLevel:        "info",
 				LogJSON:         false,
@@ -1508,7 +1508,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{GRPCPort: 8502},
 				LogLevel:      "debug",
 				LogJSON:       false,
@@ -1527,7 +1527,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{GRPCPort: 8502},
 				LogLevel:      "debug",
 				LogJSON:       true,
@@ -1546,7 +1546,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress:   "consul-server.default.svc",
+				ConsulAddress:   "consul-server.default.svc.cluster.local",
 				ConsulConfig:    &consul.Config{GRPCPort: 8502},
 				LogLevel:        "info",
 				LogJSON:         false,
@@ -1566,7 +1566,7 @@ func TestHandlerConsulDataplaneSidecar_Windows(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{GRPCPort: 8502},
 				LogLevel:      "info",
 				LogJSON:       false,

--- a/control-plane/connect-inject/webhook/container_init.go
+++ b/control-plane/connect-inject/webhook/container_init.go
@@ -38,18 +38,15 @@ type initContainerCommandData struct {
 // containerInit returns the init container spec for connect-init that polls for the service and the connect proxy service to be registered
 // so that it can save the proxy service id to the shared volume and boostrap Envoy with the proxy-id.
 func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, mpi multiPortInfo) (corev1.Container, error) {
-	var connectInjectDir, consulAddress, imageConsulK8s, initContainerCommandInterpreter, initContainerCommandTpl string
+	var connectInjectDir, imageConsulK8s, initContainerCommandInterpreter, initContainerCommandTpl string
 
 	if isWindows(pod) {
 		connectInjectDir = "C:\\consul\\connect-inject"
-		// Windows resolves DNS addresses differently. Read more: https://github.com/hashicorp-education/learn-consul-k8s-windows/blob/main/WindowsTroubleshooting.md#encountered-issues
-		consulAddress, _, _ = strings.Cut(w.ConsulAddress, ".")
 		imageConsulK8s = w.ImageConsulK8SWindows
 		initContainerCommandInterpreter = "sh"
 		initContainerCommandTpl = initContainerCommandTplWindows
 	} else {
 		connectInjectDir = "/consul/connect-inject"
-		consulAddress = w.ConsulAddress
 		imageConsulK8s = w.ImageConsulK8S
 		initContainerCommandInterpreter = "/bin/sh"
 		initContainerCommandTpl = initContainerCommandTplLinux
@@ -142,7 +139,7 @@ func (w *MeshWebhook) containerInit(namespace corev1.Namespace, pod corev1.Pod, 
 			},
 			{
 				Name:  "CONSUL_ADDRESSES",
-				Value: consulAddress,
+				Value: w.ConsulAddress,
 			},
 			{
 				Name:  "CONSUL_GRPC_PORT",

--- a/control-plane/connect-inject/webhook/container_init_test.go
+++ b/control-plane/connect-inject/webhook/container_init_test.go
@@ -163,7 +163,7 @@ func TestHandlerContainerInit(t *testing.T) {
 				return pod
 			},
 			MeshWebhook{
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{HTTPPort: 8500, GRPCPort: 8502},
 				LogLevel:      "info",
 			},
@@ -173,7 +173,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -210,7 +210,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			},
 			MeshWebhook{
 				AuthMethod:    "an-auth-method",
-				ConsulAddress: "consul-server.default.svc",
+				ConsulAddress: "consul-server.default.svc.cluster.local",
 				ConsulConfig:  &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 				LogLevel:      "debug",
 				LogJSON:       true,
@@ -223,7 +223,7 @@ func TestHandlerContainerInit(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -775,7 +775,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
 				ConsulPartition:            "",
-				ConsulAddress:              "consul-server.default.svc",
+				ConsulAddress:              "consul-server.default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`sh -ec consul-k8s-control-plane.exe connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
@@ -784,7 +784,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -819,7 +819,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "default",
 				ConsulPartition:            "default",
-				ConsulAddress:              "consul-server.default.svc",
+				ConsulAddress:              "consul-server.default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`sh -ec consul-k8s-control-plane.exe connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
@@ -828,7 +828,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -867,7 +867,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
 				ConsulPartition:            "",
-				ConsulAddress:              "consul-server.non-default.svc",
+				ConsulAddress:              "consul-server.non-default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`sh -ec consul-k8s-control-plane.exe connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
@@ -876,7 +876,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.non-default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -911,7 +911,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
 				ConsulPartition:            "non-default-part",
-				ConsulAddress:              "consul-server.non-default.svc",
+				ConsulAddress:              "consul-server.non-default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`sh -ec consul-k8s-control-plane.exe connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
@@ -920,7 +920,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.non-default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -960,7 +960,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				EnableNamespaces:           true,
 				ConsulDestinationNamespace: "non-default",
 				ConsulPartition:            "default",
-				ConsulAddress:              "consul-server.non-default.svc",
+				ConsulAddress:              "consul-server.non-default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`sh -ec consul-k8s-control-plane.exe connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
@@ -971,7 +971,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.non-default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",
@@ -1032,7 +1032,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 				ConsulDestinationNamespace: "non-default", // Overridden by mirroring
 				EnableK8SNSMirroring:       true,
 				ConsulPartition:            "non-default",
-				ConsulAddress:              "consul-server.non-default.svc",
+				ConsulAddress:              "consul-server.non-default.svc.cluster.local",
 				ConsulConfig:               &consul.Config{HTTPPort: 8500, GRPCPort: 8502, APITimeout: 5 * time.Second},
 			},
 			`sh -ec consul-k8s-control-plane.exe connect-init -pod-name=${POD_NAME} -pod-namespace=${POD_NAMESPACE} \
@@ -1043,7 +1043,7 @@ func TestHandlerContainerInit_namespacesAndPartitionsEnabled(t *testing.T) {
 			[]corev1.EnvVar{
 				{
 					Name:  "CONSUL_ADDRESSES",
-					Value: "consul-server",
+					Value: "consul-server.non-default.svc.cluster.local",
 				},
 				{
 					Name:  "CONSUL_GRPC_PORT",


### PR DESCRIPTION
# Description:

- Applied requested changes regarding the consul address value:
  -  In container_init.go and consul_dataplane_sidecar.go reverted changes and use w.ConsulAddress
  - _helpers.tpl added the .cluster.local suffix, turning the DNS address into a FQDN that works for both linux and Windows nodes.
  - Updated tests to use the new consul address value.
